### PR TITLE
Disable `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6` for SMTP

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -18,7 +18,8 @@ StandardError=inherit
 NoNewPrivileges=yes
 PrivateTmp=yes
 PrivateDevices=yes
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+# May conflict with SMTP: https://github.com/YunoHost-Apps/uptime-kuma_ynh/issues/6
+# RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictNamespaces=yes
 RestrictRealtime=yes
 DevicePolicy=closed


### PR DESCRIPTION


## Problem

- https://github.com/YunoHost-Apps/uptime-kuma_ynh/issues/6

## Solution

- Disable `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6` 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
