### PR TITLE
Fix : Websocket issue after install (see #92)

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,8 +3,8 @@ location __PATH__/ {
 
     proxy_pass http://127.0.0.1:__PORT__;
     # https://github.com/louislam/uptime-kuma/wiki/Reverse-Proxy#nginx
-    # proxy_set_header   X-Real-IP $remote_addr;
-    # proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_http_version 1.1;
     proxy_set_header   Upgrade $http_upgrade;
     proxy_set_header   Connection "upgrade";

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,6 +8,7 @@ location __PATH__/ {
     proxy_http_version 1.1;
     proxy_set_header   Upgrade $http_upgrade;
     proxy_set_header   Connection "upgrade";
+    proxy_set_header   Host $host;
     
     # Common parameter to increase upload size limit
     #client_max_body_size 50M;


### PR DESCRIPTION
## Problem

- After a fresh install or after upgrading to v1.2.39 (#92), an error message is displayed on the homepage : cannot establish websocket connection

EDIT : Documented on upstream : https://github.com/louislam/uptime-kuma/releases/tag/1.23.9

## Solution

- Uncommenting these two lines fixes the problem. These lines are coming from the upstream project documentation and should be enabled by default.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
