### PR TITLE
Updated demo site

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -12,7 +12,7 @@ maintainers = ["ketsapiwiq"]
 [upstream]
 license = "MIT"
 website = "https://uptime.kuma.pet/"
-demo = "https://demo.uptime.kuma.pet"
+demo = "https://demo.kuma.pet/start-demo"
 userdoc = "https://github.com/louislam/uptime-kuma/wiki"
 code = "https://github.com/louislam/uptime-kuma"
 


### PR DESCRIPTION
Updated to the correct demo site as per the app page to: https://demo.kuma.pet/start-demo

## Problem

- *The demo url was incorrect*

## Solution

- *Updated the demo site*

## PR Status

- [ X ] Code finished and ready to be reviewed/tested
- [ X ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)